### PR TITLE
Update homepage strapline and SEO metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # main text of home
 title: Andreas Richardson
-bio: Sustainability, energy, healthcare & data
+bio: Strategy & capital for heavy industry and the energy transition
+sub-bio: Batteries & automotive · commodities · energy infrastructure · corporate finance & value creation
 
 # twitter summary info
 description: 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,4 @@
-{% if page.title == "Home"
+{% if page.layout == "home"
    or page.title == "Blog"
    or page.title == "Projects"
    or page.title == "Tags"
@@ -18,6 +18,9 @@
 
         <h1 class="title">{{ site.title }}</h1>
         <h2 class="description">{{ site.bio }}</h2>
+        {% if site.sub-bio %}
+            <p class="sub-description">{{ site.sub-bio }}</p>
+        {% endif %}
 
         {% include social-links.html %}
     </header>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,6 +1,6 @@
-<nav class="{% if page.title == "Home" %}nav-home{% else %}nav{% endif %}">
+<nav class="{% if page.layout == "home" %}nav-home{% else %}nav{% endif %}">
     <ul class="list">
-        {% if page.title != "Home" %}
+        {% if page.layout != "home" %}
             <li class="item">
                 <a class="link" href="{{ site.url }}/">Home</a>
             </li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,13 +13,11 @@ layout: compress
     <meta name=viewport content="width=device-width, initial-scale=1">
     <meta name=author content="{{ site.title }}">
 
-    {% seo title=false %}
     {% if page.layout == "home" %}
+        {% seo title=false %}
         <title>{{ page.title | escape }}</title>
-    {% elsif page.title %}
-        <title>{{ page.title | escape }} | {{ site.title | escape }}</title>
     {% else %}
-        <title>{{ site.title | escape }}</title>
+        {% seo %}
     {% endif %}
 
     {% include favicon.html %}
@@ -51,11 +49,7 @@ layout: compress
         {% if page.layout == "post" %}
             <div class="post">
         {% else %}
-            {% if showHeader != true %}
-                <div class="page {% if page.layout == "home" %}home{% else %}{{ page.title | downcase }}{% endif %}">
-            {% else %}
-                <div class="{% if page.layout == "home" %}home{% else %}{{ page.title | downcase }}{% endif %}">
-            {% endif %}
+            <div class="page {% if page.layout == "home" %}home{% else %}{{ page.title | downcase }}{% endif %}">
         {% endif %}
 
             {{ content }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,14 @@ layout: compress
     <meta name=viewport content="width=device-width, initial-scale=1">
     <meta name=author content="{{ site.title }}">
 
-    {% seo %}
+    {% seo title=false %}
+    {% if page.layout == "home" %}
+        <title>{{ page.title | escape }}</title>
+    {% elsif page.title %}
+        <title>{{ page.title | escape }} | {{ site.title | escape }}</title>
+    {% else %}
+        <title>{{ site.title | escape }}</title>
+    {% endif %}
 
     {% include favicon.html %}
 
@@ -45,9 +52,9 @@ layout: compress
             <div class="post">
         {% else %}
             {% if showHeader != true %}
-                <div class="page {{ page.title | downcase }}">
+                <div class="page {% if page.layout == "home" %}home{% else %}{{ page.title | downcase }}{% endif %}">
             {% else %}
-                <div class="{{ page.title | downcase }}">
+                <div class="{% if page.layout == "home" %}home{% else %}{{ page.title | downcase }}{% endif %}">
             {% endif %}
         {% endif %}
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,8 @@
+---
+layout: default
+---
+{% include header.html %}
+
+{{content}}
+
+{% include footer.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,8 +1,4 @@
 ---
-layout: default
+layout: page
 ---
-{% include header.html %}
-
-{{content}}
-
-{% include footer.html %}
+{{ content }}

--- a/_sass/components/header.sass
+++ b/_sass/components/header.sass
@@ -27,8 +27,15 @@
         font-style: normal
         color: $gama
         width: 70%
-        margin: 0 auto 30px
+        margin: 0 auto 10px
 
         // if you put some links in your bio. ;)
         a
             font-weight: 200
+
+    > .sub-description
+        font-size: 1.35rem
+        font-weight: $thin-font
+        color: $alpha
+        width: 70%
+        margin: 0 auto 30px

--- a/index.html
+++ b/index.html
@@ -1,4 +1,5 @@
 ---
-layout: page
-title: Home
+layout: home
+title: Andreas Richardson — strategy & capital for heavy industry
+description: Corporate finance, value creation and capital markets across the energy transition — batteries & automotive, commodities and energy infrastructure.
 ---


### PR DESCRIPTION
- Tagline: 'Strategy & capital for heavy industry and the energy transition',
  with a new muted sub-line listing the four focus areas (site.sub-bio)
- Homepage <title> is now the exact 58-char 'Andreas Richardson — strategy &
  capital for heavy industry' via {% seo title=false %} + manual title block;
  other pages keep the 'X | Andreas Richardson' pattern
- Homepage front matter carries the full SEO title and a meta description,
  so jekyll-seo-tag emits matching og:/twitter: titles and descriptions
- New 'home' layout so header/nav/body-class logic keys off page.layout
  instead of the now-longer page title

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NXNuKtTaywop6gNnTAHt8q